### PR TITLE
Add CMake install targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(powerit INTERFACE
 target_compile_features(powerit INTERFACE cxx_std_17)
 
 # Dependencies
-option(POWERIT_FETCH_EXTERN "Fetch powerit's external dependencies" ON)
+option(POWERIT_FETCH_EXTERN "Automatically fetch powerit's external dependencies." ON)
 
 if(POWERIT_FETCH_EXTERN)
     add_subdirectory(extern)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,7 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 # Dependencies
-option(POWERIT_FETCH_EXTERN "" ON)
-if(POWERIT_FETCH_EXTERN)
-    add_subdirectory(extern)
-else()
-    find_package(ltla_aarand CONFIG REQUIRED)
-endif()
+add_subdirectory(extern)
 
 # Library
 add_library(powerit INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,14 @@ target_include_directories(powerit INTERFACE
 target_compile_features(powerit INTERFACE cxx_std_17)
 
 # Dependencies
-add_subdirectory(extern)
+option(POWERIT_FETCH_EXTERN "" ON)
+
+if(POWERIT_FETCH_EXTERN)
+    add_subdirectory(extern)
+else()
+    find_package(ltla_aarand CONFIG REQUIRED)
+endif()
+
 target_link_libraries(powerit INTERFACE ltla::aarand)
 
 # Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(powerit INTERFACE
 target_compile_features(powerit INTERFACE cxx_std_17)
 
 # Dependencies
-option(POWERIT_FETCH_EXTERN "" ON)
+option(POWERIT_FETCH_EXTERN "Fetch powerit's external dependencies" ON)
 
 if(POWERIT_FETCH_EXTERN)
     add_subdirectory(extern)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,6 @@ project(powerit
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-# Dependencies
-add_subdirectory(extern)
-
 # Library
 add_library(powerit INTERFACE)
 add_library(ltla::powerit ALIAS powerit)
@@ -19,6 +16,9 @@ target_include_directories(powerit INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ltla>)
 target_compile_features(powerit INTERFACE cxx_std_17)
+
+# Dependencies
+add_subdirectory(extern)
 target_link_libraries(powerit INTERFACE ltla::aarand)
 
 # Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,59 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.14...3.25)
 
 project(powerit
     VERSION 1.0.0
     DESCRIPTION "C++ implementation of power iterations"
     LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
+# Dependencies
+option(POWERIT_FETCH_EXTERN "" ON)
+if(POWERIT_FETCH_EXTERN)
+    add_subdirectory(extern)
+else()
+    find_package(ltla_aarand CONFIG REQUIRED)
+endif()
+
+# Library
 add_library(powerit INTERFACE)
+add_library(ltla::powerit ALIAS powerit)
 
-add_subdirectory(extern)
+target_include_directories(powerit INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ltla>)
+target_compile_features(powerit INTERFACE cxx_std_17)
+target_link_libraries(powerit INTERFACE ltla::aarand)
 
-target_link_libraries(powerit INTERFACE aarand)
-
-target_include_directories(powerit INTERFACE include/)
-
+# Tests
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    option(POWERIT_TESTS "" ON)
+else()
+    option(POWERIT_TESTS "" OFF)
+endif()
+if(POWERIT_TESTS)
     include(CTest)
     if(BUILD_TESTING)
         add_subdirectory(tests)
-    endif() 
+    endif()
 endif()
+
+# Install
+install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ltla)
+
+install(TARGETS powerit
+    EXPORT poweritTargets)
+
+install(EXPORT poweritTargets
+    FILE ltla_poweritTargets.cmake
+    NAMESPACE ltla::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ltla_powerit)
+
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/ltla_poweritConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ltla_powerit)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/ltla_poweritConfig.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ltla_powerit)

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ cmake --build . --target install
 ```
 
 By default, this will use `FetchContent` to fetch all external dependencies.
-If you want to install them manually, use `-DPOWERIT_FETCH_EXTERN=OFF` -
-use the commit hashes in [`extern/CMakeLists.txt`](extern/CMakeLists.txt) to find compatible versions.
+If you want to install them manually, use `-DPOWERIT_FETCH_EXTERN=OFF`.
+See the commit hashes in [`extern/CMakeLists.txt`](extern/CMakeLists.txt) to find compatible versions of each dependency.
 
 ### Manual
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ runner.run(order, matrix.data(), eigenvector.data(), rng);
 
 ## Building projects 
 
+### CMake with `FetchContent`
+
 If you're using CMake, you just need to add something like this to your `CMakeLists.txt`:
 
-```
+```cmake
 include(FetchContent)
 
 FetchContent_Declare(
@@ -48,13 +50,32 @@ FetchContent_MakeAvailable(powerit)
 
 Then you can link to **powerit** to make the headers available during compilation:
 
-```
+```cmake
 # For executables:
-target_link_libraries(myexe powerit)
+target_link_libraries(myexe ltla::powerit)
 
 # For libaries
-target_link_libraries(mylib INTERFACE powerit)
+target_link_libraries(mylib INTERFACE ltla::powerit)
 ```
+
+### CMake with `find_package()`
+
+```cmake
+find_package(ltla_powerit CONFIG REQUIRED)
+target_link_libraries(mylib INTERFACE ltla::powerit)
+```
+
+To install the library use:
+
+```sh
+mkdir build && cd build
+cmake .. -DPOWERIT_TESTS=OFF
+cmake --build . --target install
+```
+
+If you want to install the dependency [**aarand**](https://github.com/LTLA/aarand) manually use `-DPOWERIT_FETCH_EXTERN=OFF`.
+
+### Manual
 
 If you're not using CMake, the simple approach is to just copy the files - either directly or with Git submodules - and include their path during compilation with, e.g., GCC's `-I`.
 This requires the additional [**aarand**](https://github.com/LTLA/aarand) library for some lightweight distribution functions.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ find_package(ltla_powerit CONFIG REQUIRED)
 target_link_libraries(mylib INTERFACE ltla::powerit)
 ```
 
-To install the library use:
+To install the library, use:
 
 ```sh
 mkdir build && cd build
@@ -73,9 +73,11 @@ cmake .. -DPOWERIT_TESTS=OFF
 cmake --build . --target install
 ```
 
-If you want to install the dependency [**aarand**](https://github.com/LTLA/aarand) manually use `-DPOWERIT_FETCH_EXTERN=OFF`.
+By default, this will use `FetchContent` to fetch all external dependencies.
+If you want to install them manually, use `-DPOWERIT_FETCH_EXTERN=OFF` -
+use the commit hashes in [`extern/CMakeLists.txt`](extern/CMakeLists.txt) to find compatible versions.
 
 ### Manual
 
-If you're not using CMake, the simple approach is to just copy the files - either directly or with Git submodules - and include their path during compilation with, e.g., GCC's `-I`.
-This requires the additional [**aarand**](https://github.com/LTLA/aarand) library for some lightweight distribution functions.
+If you're not using CMake, the simple approach is to just copy the files in `include/` - either directly or with Git submodules - and include their path during compilation with, e.g., GCC's `-I`.
+This requires the external dependencies listed in [`extern/CMakeLists.txt`](extern/CMakeLists.txt), which also need to be made available during compilation.

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(ltla_aarand CONFIG REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/ltla_poweritTargets.cmake")

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,9 +1,14 @@
-include(FetchContent)
+option(POWERIT_FETCH_EXTERN "" ON)
 
-FetchContent_Declare(
-  aarand
-  GIT_REPOSITORY https://github.com/LTLA/aarand
-  GIT_TAG 84d48b65d49ce8b844398f11aff3015b86e17197
-)
+if(POWERIT_FETCH_EXTERN)
+    include(FetchContent)
+    FetchContent_Declare(
+      aarand
+      GIT_REPOSITORY https://github.com/LTLA/aarand
+      GIT_TAG 84d48b65d49ce8b844398f11aff3015b86e17197
+    )
 
-FetchContent_MakeAvailable(aarand)
+    FetchContent_MakeAvailable(aarand)
+else()
+    find_package(ltla_aarand CONFIG REQUIRED)
+endif()

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
   aarand
   GIT_REPOSITORY https://github.com/LTLA/aarand
-  GIT_TAG f61f6b08453cfa8d2681f32b795626f8cd21c724
+  GIT_TAG bd06e0d52e59e35f0456a870746a959da4bc7cb3
 )
 
 FetchContent_MakeAvailable(aarand)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,14 +1,8 @@
-option(POWERIT_FETCH_EXTERN "" ON)
+include(FetchContent)
+FetchContent_Declare(
+  aarand
+  GIT_REPOSITORY https://github.com/LTLA/aarand
+  GIT_TAG 84d48b65d49ce8b844398f11aff3015b86e17197
+)
 
-if(POWERIT_FETCH_EXTERN)
-    include(FetchContent)
-    FetchContent_Declare(
-      aarand
-      GIT_REPOSITORY https://github.com/LTLA/aarand
-      GIT_TAG 84d48b65d49ce8b844398f11aff3015b86e17197
-    )
-
-    FetchContent_MakeAvailable(aarand)
-else()
-    find_package(ltla_aarand CONFIG REQUIRED)
-endif()
+FetchContent_MakeAvailable(aarand)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
   aarand
   GIT_REPOSITORY https://github.com/LTLA/aarand
-  GIT_TAG bd06e0d52e59e35f0456a870746a959da4bc7cb3
+  GIT_TAG 84d48b65d49ce8b844398f11aff3015b86e17197
 )
 
 FetchContent_MakeAvailable(aarand)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ FetchContent_Declare(
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+option(INSTALL_GTEST "" OFF)
 FetchContent_MakeAvailable(googletest)
 
 enable_testing()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,10 @@ FetchContent_Declare(
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-option(INSTALL_GTEST "" OFF)
+
+# Avoid installing GoogleTest when installing this project.
+option(INSTALL_GTEST "Enable installation of googletest." OFF)
+
 FetchContent_MakeAvailable(googletest)
 
 enable_testing()


### PR DESCRIPTION
Follow up to https://github.com/LTLA/aarand/pull/2.

Now with external dependencies required there is an additional option `POWERIT_FETCH_EXTERN` to switch between FetchContent (default) and find_package().